### PR TITLE
chore: removes unused expiration

### DIFF
--- a/docs/DesignDoc.md
+++ b/docs/DesignDoc.md
@@ -98,7 +98,6 @@ type Invoice =
    creator: principal;
    destination: AccountIdentifier;
    details: opt Details;
-   expiration: Time;
    id: nat;
    paid: bool;
    permissions: opt Permissions;

--- a/examples/motoko-seller-client/backend/src/mocks/invoice.mo
+++ b/examples/motoko-seller-client/backend/src/mocks/invoice.mo
@@ -96,8 +96,6 @@ actor InvoiceMock {
           token;
           verifiedAtTime = null;
           paid = false;
-          // 1 week in nanoseconds
-          expiration = Time.now() + (1000 * 60 * 60 * 24 * 7 * 1_000_000);
           destination;
         };
     
@@ -353,7 +351,6 @@ actor InvoiceMock {
                       verifiedAtTime;
                       // update paid
                       paid = true;
-                      expiration = i.expiration;
                       destination = i.destination;
                     };
 

--- a/examples/motoko-seller-client/declarations/invoice/invoice.did
+++ b/examples/motoko-seller-client/declarations/invoice/invoice.did
@@ -69,7 +69,6 @@ type Invoice =
    creator: principal;
    destination: AccountIdentifier;
    details: opt Details;
-   expiration: Time;
    id: nat;
    paid: bool;
    permissions: opt Permissions;

--- a/examples/motoko-seller-client/declarations/invoice/invoice.did.d.ts
+++ b/examples/motoko-seller-client/declarations/invoice/invoice.did.d.ts
@@ -91,7 +91,6 @@ export interface Invoice {
   'paid' : boolean,
   'verifiedAtTime' : [] | [Time],
   'amountPaid' : bigint,
-  'expiration' : Time,
   'details' : [] | [Details],
   'amount' : bigint,
 }

--- a/examples/motoko-seller-client/declarations/invoice/invoice.did.js
+++ b/examples/motoko-seller-client/declarations/invoice/invoice.did.js
@@ -51,7 +51,6 @@ export const idlFactory = ({ IDL }) => {
     'paid' : IDL.Bool,
     'verifiedAtTime' : IDL.Opt(Time),
     'amountPaid' : IDL.Nat,
-    'expiration' : Time,
     'details' : IDL.Opt(Details),
     'amount' : IDL.Nat,
   });

--- a/examples/motoko-seller-client/declarations/seller/seller.did
+++ b/examples/motoko-seller-client/declarations/seller/seller.did
@@ -42,7 +42,6 @@ type Invoice =
    creator: principal;
    destination: AccountIdentifier;
    details: opt Details;
-   expiration: int;
    id: nat;
    paid: bool;
    permissions: opt Permissions;

--- a/examples/motoko-seller-client/declarations/seller/seller.did.d.ts
+++ b/examples/motoko-seller-client/declarations/seller/seller.did.d.ts
@@ -25,7 +25,6 @@ export interface Invoice {
   'paid' : boolean,
   'verifiedAtTime' : [] | [bigint],
   'amountPaid' : bigint,
-  'expiration' : bigint,
   'details' : [] | [Details],
   'amount' : bigint,
 }

--- a/examples/motoko-seller-client/declarations/seller/seller.did.js
+++ b/examples/motoko-seller-client/declarations/seller/seller.did.js
@@ -26,7 +26,6 @@ export const idlFactory = ({ IDL }) => {
     'paid' : IDL.Bool,
     'verifiedAtTime' : IDL.Opt(IDL.Int),
     'amountPaid' : IDL.Nat,
-    'expiration' : IDL.Int,
     'details' : IDL.Opt(Details),
     'amount' : IDL.Nat,
   });

--- a/examples/motoko-seller-client/src/declarations/frontend/frontend.did
+++ b/examples/motoko-seller-client/src/declarations/frontend/frontend.did
@@ -1,0 +1,140 @@
+type BatchId = nat;
+type ChunkId = nat;
+type Key = text;
+type Time = int;
+
+type CreateAssetArguments = record {
+  key: Key;
+  content_type: text;
+};
+
+// Add or change content for an asset, by content encoding
+type SetAssetContentArguments = record {
+  key: Key;
+  content_encoding: text;
+  chunk_ids: vec ChunkId;
+  sha256: opt blob;
+};
+
+// Remove content for an asset, by content encoding
+type UnsetAssetContentArguments = record {
+  key: Key;
+  content_encoding: text;
+};
+
+// Delete an asset
+type DeleteAssetArguments = record {
+  key: Key;
+};
+
+// Reset everything
+type ClearArguments = record {};
+
+type BatchOperationKind = variant {
+  CreateAsset: CreateAssetArguments;
+  SetAssetContent: SetAssetContentArguments;
+
+  UnsetAssetContent: UnsetAssetContentArguments;
+  DeleteAsset: DeleteAssetArguments;
+
+  Clear: ClearArguments;
+};
+
+type HeaderField = record { text; text; };
+
+type HttpRequest = record {
+  method: text;
+  url: text;
+  headers: vec HeaderField;
+  body: blob;
+};
+
+type HttpResponse = record {
+  status_code: nat16;
+  headers: vec HeaderField;
+  body: blob;
+  streaming_strategy: opt StreamingStrategy;
+};
+
+type StreamingCallbackHttpResponse = record {
+  body: blob;
+  token: opt StreamingCallbackToken;
+};
+
+type StreamingCallbackToken = record {
+  key: Key;
+  content_encoding: text;
+  index: nat;
+  sha256: opt blob;
+};
+
+type StreamingStrategy = variant {
+  Callback: record {
+    callback: func (StreamingCallbackToken) -> (opt StreamingCallbackHttpResponse) query;
+    token: StreamingCallbackToken;
+  };
+};
+
+service: {
+
+  get: (record {
+    key: Key;
+    accept_encodings: vec text;
+  }) -> (record {
+    content: blob; // may be the entirety of the content, or just chunk index 0
+    content_type: text;
+    content_encoding: text;
+    sha256: opt blob; // sha256 of entire asset encoding, calculated by dfx and passed in SetAssetContentArguments
+    total_length: nat; // all chunks except last have size == content.size()
+  }) query;
+
+  // if get() returned chunks > 1, call this to retrieve them.
+  // chunks may or may not be split up at the same boundaries as presented to create_chunk().
+  get_chunk: (record {
+    key: Key;
+    content_encoding: text;
+    index: nat;
+    sha256: opt blob;  // sha256 of entire asset encoding, calculated by dfx and passed in SetAssetContentArguments
+  }) -> (record { content: blob }) query;
+
+  list : (record {}) -> (vec record {
+    key: Key;
+    content_type: text;
+    encodings: vec record {
+      content_encoding: text;
+      sha256: opt blob; // sha256 of entire asset encoding, calculated by dfx and passed in SetAssetContentArguments
+      length: nat; // Size of this encoding's blob. Calculated when uploading assets.
+      modified: Time;
+    };
+  }) query;
+
+  create_batch : (record {}) -> (record { batch_id: BatchId });
+
+  create_chunk: (record { batch_id: BatchId; content: blob }) -> (record { chunk_id: ChunkId });
+
+  // Perform all operations successfully, or reject
+  commit_batch: (record { batch_id: BatchId; operations: vec BatchOperationKind }) -> ();
+
+  create_asset: (CreateAssetArguments) -> ();
+  set_asset_content: (SetAssetContentArguments) -> ();
+  unset_asset_content: (UnsetAssetContentArguments) -> ();
+
+  delete_asset: (DeleteAssetArguments) -> ();
+
+  clear: (ClearArguments) -> ();
+
+  // Single call to create an asset with content for a single content encoding that
+  // fits within the message ingress limit.
+  store: (record {
+    key: Key;
+    content_type: text;
+    content_encoding: text;
+    content: blob;
+    sha256: opt blob
+  }) -> ();
+
+  http_request: (request: HttpRequest) -> (HttpResponse) query;
+  http_request_streaming_callback: (token: StreamingCallbackToken) -> (opt StreamingCallbackHttpResponse) query;
+
+  authorize: (principal) -> ();
+}

--- a/examples/motoko-seller-client/src/declarations/frontend/frontend.did.d.ts
+++ b/examples/motoko-seller-client/src/declarations/frontend/frontend.did.d.ts
@@ -1,0 +1,117 @@
+import type { Principal } from '@dfinity/principal';
+export type BatchId = bigint;
+export type BatchOperationKind = { 'CreateAsset' : CreateAssetArguments } |
+  { 'UnsetAssetContent' : UnsetAssetContentArguments } |
+  { 'DeleteAsset' : DeleteAssetArguments } |
+  { 'SetAssetContent' : SetAssetContentArguments } |
+  { 'Clear' : ClearArguments };
+export type ChunkId = bigint;
+export type ClearArguments = {};
+export interface CreateAssetArguments { 'key' : Key, 'content_type' : string }
+export interface DeleteAssetArguments { 'key' : Key }
+export type HeaderField = [string, string];
+export interface HttpRequest {
+  'url' : string,
+  'method' : string,
+  'body' : Array<number>,
+  'headers' : Array<HeaderField>,
+}
+export interface HttpResponse {
+  'body' : Array<number>,
+  'headers' : Array<HeaderField>,
+  'streaming_strategy' : [] | [StreamingStrategy],
+  'status_code' : number,
+}
+export type Key = string;
+export interface SetAssetContentArguments {
+  'key' : Key,
+  'sha256' : [] | [Array<number>],
+  'chunk_ids' : Array<ChunkId>,
+  'content_encoding' : string,
+}
+export interface StreamingCallbackHttpResponse {
+  'token' : [] | [StreamingCallbackToken],
+  'body' : Array<number>,
+}
+export interface StreamingCallbackToken {
+  'key' : Key,
+  'sha256' : [] | [Array<number>],
+  'index' : bigint,
+  'content_encoding' : string,
+}
+export type StreamingStrategy = {
+    'Callback' : {
+      'token' : StreamingCallbackToken,
+      'callback' : [Principal, string],
+    }
+  };
+export type Time = bigint;
+export interface UnsetAssetContentArguments {
+  'key' : Key,
+  'content_encoding' : string,
+}
+export interface _SERVICE {
+  'authorize' : (arg_0: Principal) => Promise<undefined>,
+  'clear' : (arg_0: ClearArguments) => Promise<undefined>,
+  'commit_batch' : (
+      arg_0: { 'batch_id' : BatchId, 'operations' : Array<BatchOperationKind> },
+    ) => Promise<undefined>,
+  'create_asset' : (arg_0: CreateAssetArguments) => Promise<undefined>,
+  'create_batch' : (arg_0: {}) => Promise<{ 'batch_id' : BatchId }>,
+  'create_chunk' : (
+      arg_0: { 'content' : Array<number>, 'batch_id' : BatchId },
+    ) => Promise<{ 'chunk_id' : ChunkId }>,
+  'delete_asset' : (arg_0: DeleteAssetArguments) => Promise<undefined>,
+  'get' : (
+      arg_0: { 'key' : Key, 'accept_encodings' : Array<string> },
+    ) => Promise<
+      {
+        'content' : Array<number>,
+        'sha256' : [] | [Array<number>],
+        'content_type' : string,
+        'content_encoding' : string,
+        'total_length' : bigint,
+      }
+    >,
+  'get_chunk' : (
+      arg_0: {
+        'key' : Key,
+        'sha256' : [] | [Array<number>],
+        'index' : bigint,
+        'content_encoding' : string,
+      },
+    ) => Promise<{ 'content' : Array<number> }>,
+  'http_request' : (arg_0: HttpRequest) => Promise<HttpResponse>,
+  'http_request_streaming_callback' : (
+      arg_0: StreamingCallbackToken,
+    ) => Promise<[] | [StreamingCallbackHttpResponse]>,
+  'list' : (arg_0: {}) => Promise<
+      Array<
+        {
+          'key' : Key,
+          'encodings' : Array<
+            {
+              'modified' : Time,
+              'sha256' : [] | [Array<number>],
+              'length' : bigint,
+              'content_encoding' : string,
+            }
+          >,
+          'content_type' : string,
+        }
+      >
+    >,
+  'set_asset_content' : (arg_0: SetAssetContentArguments) => Promise<undefined>,
+  'store' : (
+      arg_0: {
+        'key' : Key,
+        'content' : Array<number>,
+        'sha256' : [] | [Array<number>],
+        'content_type' : string,
+        'content_encoding' : string,
+      },
+    ) => Promise<undefined>,
+  'unset_asset_content' : (arg_0: UnsetAssetContentArguments) => Promise<
+      undefined
+    >,
+}

--- a/examples/motoko-seller-client/src/declarations/frontend/frontend.did.js
+++ b/examples/motoko-seller-client/src/declarations/frontend/frontend.did.js
@@ -1,0 +1,155 @@
+export const idlFactory = ({ IDL }) => {
+  const ClearArguments = IDL.Record({});
+  const BatchId = IDL.Nat;
+  const Key = IDL.Text;
+  const CreateAssetArguments = IDL.Record({
+    'key' : Key,
+    'content_type' : IDL.Text,
+  });
+  const UnsetAssetContentArguments = IDL.Record({
+    'key' : Key,
+    'content_encoding' : IDL.Text,
+  });
+  const DeleteAssetArguments = IDL.Record({ 'key' : Key });
+  const ChunkId = IDL.Nat;
+  const SetAssetContentArguments = IDL.Record({
+    'key' : Key,
+    'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'chunk_ids' : IDL.Vec(ChunkId),
+    'content_encoding' : IDL.Text,
+  });
+  const BatchOperationKind = IDL.Variant({
+    'CreateAsset' : CreateAssetArguments,
+    'UnsetAssetContent' : UnsetAssetContentArguments,
+    'DeleteAsset' : DeleteAssetArguments,
+    'SetAssetContent' : SetAssetContentArguments,
+    'Clear' : ClearArguments,
+  });
+  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+  });
+  const StreamingCallbackToken = IDL.Record({
+    'key' : Key,
+    'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'index' : IDL.Nat,
+    'content_encoding' : IDL.Text,
+  });
+  const StreamingCallbackHttpResponse = IDL.Record({
+    'token' : IDL.Opt(StreamingCallbackToken),
+    'body' : IDL.Vec(IDL.Nat8),
+  });
+  const StreamingStrategy = IDL.Variant({
+    'Callback' : IDL.Record({
+      'token' : StreamingCallbackToken,
+      'callback' : IDL.Func(
+          [StreamingCallbackToken],
+          [IDL.Opt(StreamingCallbackHttpResponse)],
+          ['query'],
+        ),
+    }),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'streaming_strategy' : IDL.Opt(StreamingStrategy),
+    'status_code' : IDL.Nat16,
+  });
+  const Time = IDL.Int;
+  return IDL.Service({
+    'authorize' : IDL.Func([IDL.Principal], [], []),
+    'clear' : IDL.Func([ClearArguments], [], []),
+    'commit_batch' : IDL.Func(
+        [
+          IDL.Record({
+            'batch_id' : BatchId,
+            'operations' : IDL.Vec(BatchOperationKind),
+          }),
+        ],
+        [],
+        [],
+      ),
+    'create_asset' : IDL.Func([CreateAssetArguments], [], []),
+    'create_batch' : IDL.Func(
+        [IDL.Record({})],
+        [IDL.Record({ 'batch_id' : BatchId })],
+        [],
+      ),
+    'create_chunk' : IDL.Func(
+        [IDL.Record({ 'content' : IDL.Vec(IDL.Nat8), 'batch_id' : BatchId })],
+        [IDL.Record({ 'chunk_id' : ChunkId })],
+        [],
+      ),
+    'delete_asset' : IDL.Func([DeleteAssetArguments], [], []),
+    'get' : IDL.Func(
+        [IDL.Record({ 'key' : Key, 'accept_encodings' : IDL.Vec(IDL.Text) })],
+        [
+          IDL.Record({
+            'content' : IDL.Vec(IDL.Nat8),
+            'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+            'content_type' : IDL.Text,
+            'content_encoding' : IDL.Text,
+            'total_length' : IDL.Nat,
+          }),
+        ],
+        ['query'],
+      ),
+    'get_chunk' : IDL.Func(
+        [
+          IDL.Record({
+            'key' : Key,
+            'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+            'index' : IDL.Nat,
+            'content_encoding' : IDL.Text,
+          }),
+        ],
+        [IDL.Record({ 'content' : IDL.Vec(IDL.Nat8) })],
+        ['query'],
+      ),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'http_request_streaming_callback' : IDL.Func(
+        [StreamingCallbackToken],
+        [IDL.Opt(StreamingCallbackHttpResponse)],
+        ['query'],
+      ),
+    'list' : IDL.Func(
+        [IDL.Record({})],
+        [
+          IDL.Vec(
+            IDL.Record({
+              'key' : Key,
+              'encodings' : IDL.Vec(
+                IDL.Record({
+                  'modified' : Time,
+                  'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+                  'length' : IDL.Nat,
+                  'content_encoding' : IDL.Text,
+                })
+              ),
+              'content_type' : IDL.Text,
+            })
+          ),
+        ],
+        ['query'],
+      ),
+    'set_asset_content' : IDL.Func([SetAssetContentArguments], [], []),
+    'store' : IDL.Func(
+        [
+          IDL.Record({
+            'key' : Key,
+            'content' : IDL.Vec(IDL.Nat8),
+            'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+            'content_type' : IDL.Text,
+            'content_encoding' : IDL.Text,
+          }),
+        ],
+        [],
+        [],
+      ),
+    'unset_asset_content' : IDL.Func([UnsetAssetContentArguments], [], []),
+  });
+};
+export const init = ({ IDL }) => { return []; };

--- a/examples/motoko-seller-client/src/declarations/frontend/index.js
+++ b/examples/motoko-seller-client/src/declarations/frontend/index.js
@@ -1,0 +1,38 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from './frontend.did.js';
+export { idlFactory } from './frontend.did.js';
+// CANISTER_ID is replaced by webpack based on node environment
+export const canisterId = process.env.FRONTEND_CANISTER_ID;
+
+/**
+ * 
+ * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
+ * @param {{agentOptions?: import("@dfinity/agent").HttpAgentOptions; actorOptions?: import("@dfinity/agent").ActorConfig}} [options]
+ * @return {import("@dfinity/agent").ActorSubclass<import("./frontend.did.js")._SERVICE>}
+ */
+ export const createActor = (canisterId, options) => {
+  const agent = new HttpAgent({ ...options?.agentOptions });
+  
+  // Fetch root key for certificate validation during development
+  if(process.env.NODE_ENV !== "production") {
+    agent.fetchRootKey().catch(err=>{
+      console.warn("Unable to fetch root key. Check to ensure that your local replica is running");
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options?.actorOptions,
+  });
+};
+  
+/**
+ * A ready-to-use agent for the frontend canister
+ * @type {import("@dfinity/agent").ActorSubclass<import("./frontend.did.js")._SERVICE>}
+ */
+ export const frontend = createActor(canisterId);

--- a/src/invoice/ICPLedger.mo
+++ b/src/invoice/ICPLedger.mo
@@ -222,7 +222,6 @@ module {
                   verifiedAtTime;
                   // update paid
                   paid = true; // since transfer has succeeded
-                  expiration = i.expiration;
                   destination = i.destination;
                 };
 

--- a/src/invoice/Types.mo
+++ b/src/invoice/Types.mo
@@ -39,7 +39,6 @@ module {
     token : TokenVerbose;
     verifiedAtTime : ?Time.Time;
     paid : Bool;
-    expiration : Time.Time;
     destination : AccountIdentifier;
   };
 // #endregion

--- a/src/invoice/main.mo
+++ b/src/invoice/main.mo
@@ -94,8 +94,6 @@ actor Invoice {
           token;
           verifiedAtTime = null;
           paid = false;
-          // 1 week in nanoseconds
-          expiration = Time.now() + (1000 * 60 * 60 * 24 * 7 * 1_000_000);
           destination;
         };
 

--- a/test/e2e/src/declarations/invoice/invoice.did
+++ b/test/e2e/src/declarations/invoice/invoice.did
@@ -69,7 +69,6 @@ type Invoice =
    creator: principal;
    destination: AccountIdentifier;
    details: opt Details;
-   expiration: Time;
    id: nat;
    paid: bool;
    permissions: opt Permissions;
@@ -195,7 +194,6 @@ service : {
    (GetAccountIdentifierResult) query;
   get_balance: (GetBalanceArgs) -> (GetBalanceResult);
   get_invoice: (GetInvoiceArgs) -> (GetInvoiceResult) query;
-  remaining_cycles: () -> (nat) query;
   transfer: (TransferArgs) -> (TransferResult);
   verify_invoice: (VerifyInvoiceArgs) -> (VerifyInvoiceResult);
 }

--- a/test/e2e/src/declarations/invoice/invoice.did.d.ts
+++ b/test/e2e/src/declarations/invoice/invoice.did.d.ts
@@ -81,7 +81,6 @@ export interface Invoice {
   'paid' : boolean,
   'verifiedAtTime' : [] | [Time],
   'amountPaid' : bigint,
-  'expiration' : Time,
   'details' : [] | [Details],
   'amount' : bigint,
 }
@@ -139,7 +138,6 @@ export interface _SERVICE {
     >,
   'get_balance' : (arg_0: GetBalanceArgs) => Promise<GetBalanceResult>,
   'get_invoice' : (arg_0: GetInvoiceArgs) => Promise<GetInvoiceResult>,
-  'remaining_cycles' : () => Promise<bigint>,
   'transfer' : (arg_0: TransferArgs) => Promise<TransferResult>,
   'verify_invoice' : (arg_0: VerifyInvoiceArgs) => Promise<VerifyInvoiceResult>,
 }

--- a/test/e2e/src/declarations/invoice/invoice.did.js
+++ b/test/e2e/src/declarations/invoice/invoice.did.js
@@ -51,7 +51,6 @@ export const idlFactory = ({ IDL }) => {
     'paid' : IDL.Bool,
     'verifiedAtTime' : IDL.Opt(Time),
     'amountPaid' : IDL.Nat,
-    'expiration' : Time,
     'details' : IDL.Opt(Details),
     'amount' : IDL.Nat,
   });
@@ -173,7 +172,6 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_balance' : IDL.Func([GetBalanceArgs], [GetBalanceResult], []),
     'get_invoice' : IDL.Func([GetInvoiceArgs], [GetInvoiceResult], ['query']),
-    'remaining_cycles' : IDL.Func([], [IDL.Nat], ['query']),
     'transfer' : IDL.Func([TransferArgs], [TransferResult], []),
     'verify_invoice' : IDL.Func([VerifyInvoiceArgs], [VerifyInvoiceResult], []),
   });


### PR DESCRIPTION
Now that refund is no longer included, we can remove the expiration field as well, as there is no clear use case for it.

Closes #27 